### PR TITLE
Better error handling in Email-MSalarm

### DIFF
--- a/IITS.ps1
+++ b/IITS.ps1
@@ -75,10 +75,17 @@ function Email-MSalarm
 
     Begin
     {
+        try
+        {
+        $ErrorLog = "$env:TEMP\EmailMSalarm_IITS.txt"
         $key = Get-Content "C:\IITS_Scripts\Key.key" -ErrorAction Stop -ErrorVariable CurrentError
         $password = Get-Content "C:\IITS_Scripts\passwd.txt" | ConvertTo-SecureString -Key $key
         $credentials = new-object -typename System.Management.Automation.PSCredential -argumentlist "forecast@integratedit.com",$password
-        $ErrorLog = "$env:TEMP\EmailMSalarm_IITS.txt"
+        }
+        Catch
+        {
+        "$(Get-Date) - Couldn't get a variable.  Error= $CurrentError ." | Out-File -FilePath $ErrorLog -Force -Append
+        }
     }
     Process
     {


### PR DESCRIPTION
Added try catch block so that any issues with getting the key file will be outputted to an error log located in the temp directory.