### PR TITLE
Error handling for Get-EsetLink

### DIFF
--- a/IITS.ps1
+++ b/IITS.ps1
@@ -566,7 +566,7 @@ function Get-EsetLink
                   PositionalBinding=$false,
                   HelpUri = 'http://www.microsoft.com/',
                   ConfirmImpact='Medium')]
-    [Alias("Get-ESET")]
+    [Alias("Get-EsetAgent")]
     [OutputType([String])]
     Param
     (
@@ -585,23 +585,23 @@ function Get-EsetLink
     
     Begin
     {
-    # Get the OS architecture of the target (Windows) machine.
-    (Get-WmiObject Win32_OperatingSystem).OSArchitecture -match '\d+' | Out-Null
-    [Int]$machOS=$matches[0]
+        # Get the OS architecture of the target (Windows) machine. DO NOT output the actual match result.
+        (Get-WmiObject Win32_OperatingSystem).OSArchitecture -match '\d+' | Out-Null
+        [Int]$machOS=$matches[0]
     
-    # RegEx the machine name to extract the group name.
-    $machName -match '[\w-]+$' | Out-Null
-    [String]$groupName = $matches[0]
+        # RegEx the machine name to extract the group name. DO NOT output the actual match result.
+        $machName -match '[\w-]+$' | Out-Null
+        [String]$groupName = $matches[0]
     }
     Process
     {
-    # Import the key and search for the group and OS architecture. Save the result to a container.
-    $orgLink = (Import-Csv "C:\IITS_Scripts\EsetKey.csv" | where{$_.machOrg -eq $groupName} | where{$_.machOS -eq $machOS} | % link)
+        # Import the key and search for the group and OS architecture. Save the result to a container.
+        $orgLink = (Import-Csv "C:\IITS_Scripts\EsetKey.csv" | where{$_.machOrg -eq $groupName} | where{$_.machOS -eq $machOS} | % link)
     }
     End
     {
-    # Print the container with the ESET link.
-    return $orgLink
+        # Print the container with the ESET link.
+        return $orgLink
     }
 }
 

--- a/IITS.ps1
+++ b/IITS.ps1
@@ -1385,7 +1385,7 @@ function Check-PSVersion
     }
     else {return $false}
 }
-}
+
 <#
 .Synopsis
    This function Calculate the projection of how much space is left and in how much time the space will exhaust

--- a/IITS.ps1
+++ b/IITS.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .Synopsis
    This function will find the Kaseya Machine ID of the computer.  It will find the computer name if there is no kaseya agent installed.
 .DESCRIPTION
@@ -559,11 +559,11 @@ function hide-user-from-GAL
 .Synopsis
    Match an organization and a Windows OS architecture (32 or 64) to download an installer. Only works on a single machine at a time.
 .DESCRIPTION
-   Determine the root org (groupName) based on a given machine ID (machName). Determine the OS architecture (machOS) of the machine this script is run on (which will be the same machine in machName). Match machOrg and machOS against key ESETAgentKey.csv to get a Dropbox download link to a company-specific ESET Agent installer, then move the installer to the Kaseya agent Temp folder (C:\IITS_Mgmt\Temp\).
+   Determine the root org (groupName) based on a given machine ID (machName). Determine the OS architecture (machOS) of the machine this script is run on (which will be the same machine in machName). Match machOrg and machOS against key EsetKey.csv to get a Dropbox download link to a company-specific ESET Agent installer.
 .EXAMPLE
-   Get-EsetLink [-machName] sccit [-esetKey] C:\Key.csv
+   Get-EsetLink [-machName] my.machine.sccit
 .INPUTS
-   machName (string), esetKey (string)
+   machName (string)
 .OUTPUTS
    URL (string)
 .FUNCTIONALITY
@@ -592,15 +592,6 @@ function Get-EsetLink
         [ValidateNotNullOrEmpty()]
         [Alias("name","machine")] 
         [String]$machName,
-        
-        # The source location of the ESET key.
-        [Parameter(Mandatory=$true,
-                   Position=1,
-                   ParameterSetName='Parameter Set 1')]
-        [ValidateNotNull()]
-        [ValidateNotNullOrEmpty()]
-        [Alias('key','list','source')]
-        $esetKey
     )
     
     Begin
@@ -616,7 +607,7 @@ function Get-EsetLink
     Process
     {
     # Import the key and search for the group and OS architecture. Save the result to a container.
-    $orgLink = (Import-Csv $esetKey | where{$_.machOrg -eq $groupName} | where{$_.machOS -eq $machOS} | % link)
+    $orgLink = (Import-Csv "C:\IITS_Scripts\EsetKey.csv" | where{$_.machOrg -eq $groupName} | where{$_.machOS -eq $machOS} | % link)
     }
     End
     {

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 
 This file contains all of the functions that IITS distributes to all managed services machines. The current list of command available are:
 |Script|Author|
-
 |---|---|
 |Check-PSVersion|Antonio Vincentelli|
 |Create-Zip|Darren Khan|

--- a/README.md
+++ b/README.md
@@ -10,6 +10,6 @@ This file contains all of the functions that IITS distributes to all managed ser
 |Get-EsetLink|Antonio Vincentelli|
 |Get-KaseyaMachineID|Darren Khan|
 |Get-MailFlowStats|Darren Khan|
+|Get-ServiceAccount|Darren Khan|
 |hide-user-from-GAL|Michael Surtees|
 |Toggle-ActionCenter|Darren Khan|
-|Get-ServiceAccount|Darren Khan|

--- a/README.md
+++ b/README.md
@@ -12,3 +12,4 @@ This file contains all of the functions that IITS distributes to all managed ser
 |Get-MailFlowStats|Darren Khan|
 |hide-user-from-GAL|Michael Surtees|
 |Toggle-ActionCenter|Darren Khan|
+|Get-ServiceAccount|Darren Khan|

--- a/README.md
+++ b/README.md
@@ -2,11 +2,13 @@
 
 This file contains all of the functions that IITS distributes to all managed services machines.  The current list of command available are:
 
-* Email-MSalarm
-* external-kaseya-push
-* get-app-version
-* Get-EsetLink
-* Get-KaseyaMachineID
-* Get-MailFlowStats
-* hide-user-from-GAL
-* Toggle-ActionCenter
+|Script|Author|
+|---|---|
+|Email-MSalarm|Darren Khan|
+|external-kaseya-push|Michael Surtees|
+|get-app-version|Michael Surtees|
+|Get-EsetLink|Antonio Vincentelli|
+|Get-KaseyaMachineID|Darren Khan|
+|Get-MailFlowStats|Darren Khan|
+|hide-user-from-GAL|Michael Surtees|
+|Toggle-ActionCenter|Darren Khan|

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
-This file contains all of the functions that IITS distributes to all managed services machines.  The current list of command available are:
-
+This file contains all of the functions that IITS distributes to all managed services machines. The current list of command available are:
 |Script|Author|
+
 |---|---|
 |Check-PSVersion|Antonio Vincentelli|
 |Create-Zip|Darren Khan|
@@ -16,8 +16,10 @@ This file contains all of the functions that IITS distributes to all managed ser
 |Get-InstalledPrograms|Darren Khan|
 |Get-KaseyaMachineID|Darren Khan|
 |Get-MailFlowStats|Darren Khan|
+|Get-Projection|Arjun Gheek|
 |Get-ServiceAccount|Darren Khan|
 |Hide-User-From-GAL|Michael Surtees|
 |Remove-Application|Darren Khan|
 |Remove-Outlook-Automap|Michael Surtees|
 |Toggle-ActionCenter|Darren Khan|
+


### PR DESCRIPTION
Added error handling for Get-EsetLink, including a new $Logging parameter. Converted $machName from parameter to simple variable that is fed by Get-KaseyaMachineID.